### PR TITLE
Minor updates to CDA to FHIR maps

### DIFF
--- a/cdatofhir_card.http
+++ b/cdatofhir_card.http
@@ -1,8 +1,8 @@
 ### Create and Update CDA maps for converting to FHIR with RESTClient and running matchbox (locally)
 ### Note: POST the maps in the following order, if you update one map you need to repost also the maps below
 
-### @host = https://test.ahdis.ch/matchbox/fhir
-@host = http://localhost:8080/matchboxv3/fhir
+@host = https://test.ahdis.ch/matchbox/fhir
+# @host = http://localhost:8080/matchboxv3/fhir
 
 ### 1. POST CdaToFhirTypes.map
 POST {{host}}/StructureMap HTTP/1.1

--- a/cdatofhir_dispense.http
+++ b/cdatofhir_dispense.http
@@ -1,8 +1,8 @@
 ### Create and Update CDA maps for converting to FHIR with RESTClient and running matchbox (locally)
 ### Note: POST the maps in the following order, if you update one map you need to repost also the maps below
 
-### @host = https://test.ahdis.ch/matchbox/fhir
-@host = http://localhost:8080/matchbox/fhir
+@host = https://test.ahdis.ch/matchbox/fhir
+# @host = http://localhost:8080/matchbox/fhir
 
 
 ### 1. POST CdaToFhirTypes.map

--- a/cdatofhir_padv.http
+++ b/cdatofhir_padv.http
@@ -1,8 +1,8 @@
 ### Create and Update CDA maps for converting to FHIR with RESTClient and running matchbox (locally)
 ### Note: POST the maps in the following order, if you update one map you need to repost also the maps below
 
-### @host = https://test.ahdis.ch/matchbox/fhir
-@host = http://localhost:8080/matchbox/fhir
+@host = https://test.ahdis.ch/matchbox/fhir
+# @host = http://localhost:8080/matchbox/fhir
 
 
 

--- a/cdatofhir_prescription.http
+++ b/cdatofhir_prescription.http
@@ -1,8 +1,8 @@
 ### Create and Update CDA maps for converting to FHIR with RESTClient and running matchbox (locally)
 ### Note: POST the maps in the following order, if you update one map you need to repost also the maps below
 
-### @host = https://test.ahdis.ch/matchbox/fhir
-@host = http://localhost:8080/matchbox/fhir
+@host = https://test.ahdis.ch/matchbox/fhir
+# @host = http://localhost:8080/matchbox/fhir
 
 
 

--- a/cdatofhir_treatmentplan.http
+++ b/cdatofhir_treatmentplan.http
@@ -1,8 +1,8 @@
 ### Create and Update CDA maps for converting to FHIR with RESTClient and running matchbox (locally)
 ### Note: POST the maps in the following order, if you update one map you need to repost also the maps below
 
-### @host = https://test.ahdis.ch/matchbox/fhir
-@host = http://localhost:8080/matchbox/fhir
+@host = https://test.ahdis.ch/matchbox/fhir
+# @host = http://localhost:8080/matchbox/fhir
 
 
 

--- a/input/maps/CdaChEmedToBundle.map
+++ b/input/maps/CdaChEmedToBundle.map
@@ -358,7 +358,7 @@ group DispenseItemEntryContentModule(source section : Section, source src : Supp
     -> medicationDispense.extension as ext then MTPReferenceEntryContentModule(entry, ext) "MTPReferenceEntry";   
 
   src.entryRelationship as entry where (typeCode='COMP' and act.templateId.where(root='2.16.756.5.30.1.1.10.4.2').exists()) then {
-    entry.act as act -> medicationDispense.note as note then AnnotationComment(sact, note) "annotation";
+    entry.act as act -> medicationDispense.note as note then AnnotationComment(act, note) "annotation";
   } "entryRelationShip-2.16.756.5.30.1.1.10.4.2";  
 
   src.entryRelationship as entry where (typeCode='COMP' and act.templateId.where(root='1.3.6.1.4.1.19376.1.9.1.3.9.2').exists()) then {


### PR DESCRIPTION
(Submitting PR to branch 'Cda_model_update' as for some reason I couldn't directly push despite accepting the invite etc).

Only 2 small changes here:
* switching `.http` files to point to public server instead of `localhost`
* fix typo that caused a transform error

### Summary of all CDA to FHIR `http` files 

#### cdatofhir.http
* maps all load
* transforms all good

#### cdatofhir_treatmentplan.http
* maps all load
* transforms all give error "`Failed to call access method: java.lang.NullPointerException`" - I don't know how to resolve this error

cdatofhir_prescription.http
* maps all load
* transforms all good

#### cdatofhir_padv.http
* maps all load
* transforms all give error "`Failed to call access method: java.lang.NullPointerException`" - I don't know how to resolve this 

#### cdatofhir_list.http
* maps all load
* fix for typo 'sact' (via commit in this PR)
* transforms all good

#### cdatofhir_dispense.http
* maps all load
* transforms all good

#### cdatofhir_card.http
* maps all load
* transforms
  * line 47 for `./input/cda-ch-emed/2-7-MedicationCard.xml` - error "`Failed to call access method: java.lang.NullPointerException`" - as above
  * line 56 `./input/generated-files/cda-ch-emed-2-7-MedicationCard.xml` - error "`Failed to call access method: java.lang.NullPointerException`" - as above
  * line 64 for ` ./input/cda-ch-emed/pmlc2.xml` - error "`Failed to call access method: org.hl7.fhir.exceptions.DefinitionException: Type 'ns2:COCT_MT230100UV.Substance' is not an acceptable type for 'ingredient' on property PharmIngredient.ingredient`" - I can't figure out how to resolve this one
  * line 72 `./input/generated-files/cda-ch-emed-2-7-MedicationCard-UUIDfullUrl.xml` => file does not exist